### PR TITLE
Inject config resolver into children provider

### DIFF
--- a/EventListener/Type.php
+++ b/EventListener/Type.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Repository;
 use Novactive\Bundle\eZExtraBundle\Core\Helper\eZ\Content as ContentHelper;
 use Novactive\Bundle\eZExtraBundle\Core\Helper\eZ\Search as SearchHelper;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ChainConfigResolver as ConfigResolver;
 
 /**
  * Class Type
@@ -65,6 +66,13 @@ abstract class Type
     protected $searchHelper;
 
     /**
+     * Config resolver
+     *
+     * @var ConfigResolver
+     */
+    protected $configResolver;
+
+    /**
      * Set the Content View
      *
      * @param ContentView $contentView
@@ -97,15 +105,17 @@ abstract class Type
     /**
      * Constructor
      *
-     * @param Repository    $repository
-     * @param ContentHelper $contentHelper
-     * @param SearchHelper  $searchHelper
+     * @param Repository      $repository
+     * @param ContentHelper   $contentHelper
+     * @param SearchHelper    $searchHelper
+     * @param ConfigResolver  $configResolver
      */
-    public function __construct( Repository $repository, ContentHelper $contentHelper, SearchHelper $searchHelper )
+    public function __construct( Repository $repository, ContentHelper $contentHelper, SearchHelper $searchHelper, ConfigResolver $configResolver )
     {
-        $this->repository    = $repository;
-        $this->contentHelper = $contentHelper;
-        $this->searchHelper  = $searchHelper;
+        $this->repository      = $repository;
+        $this->contentHelper   = $contentHelper;
+        $this->searchHelper    = $searchHelper;
+        $this->configResolver  = $configResolver;
     }
 
     /**

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -45,7 +45,7 @@ services:
     novactive.ezextra.abstract.children.provider:
         class: %novaezextra.abstract.children.provider.class%
         abstract: true
-        arguments: [@ezpublish.api.repository, @novactive.ezextra.content.helper, @novactive.ezextra.search.helper]
+        arguments: [@ezpublish.api.repository, @novactive.ezextra.content.helper, @novactive.ezextra.search.helper, @ezpublish.config.resolver]
 
     novactive.ezextra.form.type.search.simple:
         class: %novactive.ezextra.form.type.search.simple.class%


### PR DESCRIPTION
In my use case, it allows me to get the languages of the current siteaccess, so I can use them as a search filter (new Criterion\LanguageCode($this->configResolver->getParameter('languages'))).
