### PR TITLE
* ibexa4 : FIX eznova_content_by_contentinfo not found in cnp project

### DIFF
--- a/bundle/Twig/ContentExtension.php
+++ b/bundle/Twig/ContentExtension.php
@@ -27,19 +27,16 @@ use Twig\TwigFunction;
 
 class ContentExtension extends AbstractExtension
 {
-    /**
-     * @var Repository
-     */
-    private $repository;
 
-    public function __construct(Repository $repository)
-    {
-        $this->repository = $repository;
+    public function __construct(
+        protected Repository $repository
+    ) {
     }
 
     public function getFunctions(): array
     {
         return [
+            new TwigFunction('eznova_content_by_contentinfo', [$this, 'contentByContentInfo']),
             new TwigFunction('eznova_parentcontent_by_contentinfo', [$this, 'parentContentByContentInfo']),
             new TwigFunction('eznova_location_by_content', [$this, 'locationByContent']),
             new TwigFunction('eznova_relation_field_to_content', [$this, 'relationFieldToContent']),
@@ -49,6 +46,12 @@ class ContentExtension extends AbstractExtension
             ),
             new TwigFunction('eznova_is_rich_text_really_empty', [$this, 'isRichTextReallyEmpty']),
         ];
+    }
+    public function contentByContentInfo(ContentInfo $contentInfo): Content
+    {
+        $location = $this->repository->getLocationService()->loadLocation($contentInfo->mainLocationId);
+
+        return $location->getContent();
     }
 
     public function parentContentByContentInfo(ContentInfo $contentInfo): Content


### PR DESCRIPTION
Thanks for your pull request! We love contributions.

However, this repository is what we call a "subtree split": a read-only copy of one directory of the main repository. It is used by Composer to allow developers to depend on specific bundles.

If you want to contribute, you should instead open a pull request on the main repository:

https://github.com/Novactive/Nova-eZPlatform-Bundles

Thank you for your contribution!

PS: if you haven't already, please add tests.
